### PR TITLE
Remove obfuscation flag from APK build command

### DIFF
--- a/.github/workflows/flutter_build_and_release.yml
+++ b/.github/workflows/flutter_build_and_release.yml
@@ -63,7 +63,7 @@ jobs:
       # 5️⃣  Build release APK
       - name: 🏗️ Build Android release APK
         run: |
-          flutter build apk --release --obfuscate \
+          flutter build apk --release \
             --build-name "$VERSION_PREFIX-${{ github.run_number }}" \
             --build-number "${{ github.run_number }}"
 


### PR DESCRIPTION
Eliminate the obfuscation flag from the APK build command to simplify the build process.