### PR TITLE
Downgrade action-gh-release to v1 for compatibility

### DIFF
--- a/.github/workflows/flutter_build_and_release.yml
+++ b/.github/workflows/flutter_build_and_release.yml
@@ -85,7 +85,7 @@ jobs:
           name: apk-release
           path: ./artifacts
       - name: 🏷️ Create GitHub Release (APK & IPA)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: "release-${{ github.run_number }}"
           name: ${{ format('Release v{0}+{1}', needs.android-release-upload.outputs.version_prefix, github.run_number) }}


### PR DESCRIPTION
Downgrade the action-gh-release GitHub Action to version 1 to ensure compatibility with the current workflow.